### PR TITLE
Fix typo on Quad Menu ‘Convert to’ menu item

### DIFF
--- a/menu/quad/menu_standard.py
+++ b/menu/quad/menu_standard.py
@@ -69,7 +69,7 @@ def get_view3d_transform(ctx):
 	items.append(QuadItem("Geometry Node Editor...", f, t, n, c0214, n))
 	items.append(QuadItem(n, f, f, n, n, n))
 	submenu = get_view3d_transform_convert_to_sub(ctx)
-	items.append(QuadItem("Conver to", f, f, submenu, n, n))
+	items.append(QuadItem("Convert to", f, f, submenu, n, n))
 	return "Transform", items, 1
 
 


### PR DESCRIPTION
The 'Convert to' quad menu item is misspelt.

### Current
<img width="365" alt="Screen Shot 2022-10-04 at 10 34 53" src="https://user-images.githubusercontent.com/1848516/193888615-0ebcbc96-cfd6-417f-94fe-4d8e50cf8833.png">

### Fixed
<img width="359" alt="Screen Shot 2022-10-04 at 10 35 27" src="https://user-images.githubusercontent.com/1848516/193888649-a3490789-628e-4924-a874-f1969f59346a.png">
